### PR TITLE
Update primary acting file path in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "tiny-angular-wordcloud",
   "description": "A wordcloud generator for angular without external dependencies.",
-  "main": "dist/cloudDirective.js",
+  "main": "dist/tangCloud.js",
   "ignore": [
     ".jshintrc",
     ".gitignore",


### PR DESCRIPTION
The "main" property in bower.json is used by build tools like Gulp, so its value must be correct.
